### PR TITLE
fix(deps): Update prettier and associated dependencies

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,20 +1,27 @@
 module.exports = {
 	root: true,
 	parser: '@typescript-eslint/parser',
-	extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'prettier'],
-	plugins: ['svelte3', '@typescript-eslint'],
+	extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'plugin:svelte/recommended', 'prettier'],
+	plugins: ['@typescript-eslint'],
 	ignorePatterns: ['*.cjs'],
 	overrides: [{ files: ['*.svelte'], processor: 'svelte3/svelte3' }],
-	settings: {
-		'svelte3/typescript': () => require('typescript')
-	},
 	parserOptions: {
 		sourceType: 'module',
-		ecmaVersion: 2020
+		ecmaVersion: 2020,
+		extraFileExtensions: ['.svelte']
 	},
 	env: {
 		browser: true,
 		es2017: true,
 		node: true
-	}
+	},
+	overrides: [
+		{
+			files: ['*.svelte'],
+			parser: 'svelte-eslint-parser',
+			parserOptions: {
+				parser: '@typescript-eslint/parser'
+			}
+		}
+	]
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -4,6 +4,6 @@
 	"singleQuote": true,
 	"trailingComma": "none",
 	"printWidth": 100,
-	"pluginSearchDirs": ["."],
+	"plugins": ["prettier-plugin-svelte"],
 	"overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }]
 }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "bootstrap": "^5.3.2",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
-    "eslint-plugin-svelte3": "^4.0.0",
+    "eslint-plugin-svelte": "^2.0.0",
     "google-auth-library": "^9.4.1",
     "jsonwebtoken": "^9.0.2",
     "prettier": "^3.1.1",


### PR DESCRIPTION
Some files in the project use a mix of tabs and spaces for formatting making code more difficult to read (for example, [layout.svelte](https://github.com/nstuyvesant/sveltekit-auth-example/blob/master/src/routes/%2Blayout.svelte#L34-L47)). Prettier could fix the inconsistent formatting but currently fails to run due to some outdated dependencies/configuration (see below).

Fixing prettier configuration/dependencies to be able to run it on the project.

---
```
npx prettier . --check
Checking formatting...
[warn] Ignored unknown option { pluginSearchDirs: ["."] }.
...
src/routes/+error.svelte
[error] Couldn't resolve parser "svelte".
```