### PR TITLE
chore(prettier): Exclude formatting commit from blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Reformatted with prettier
+11897c3c41550ee321aa9e865683eb2de9c1a505


### PR DESCRIPTION
Github supports `.git-blame-ignore-revs` files to [exclude commits](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view) from the blame view. This can be useful when looking at the blame view of the file to see what commit introduced some functionality.

For example, the blame view of [layout.svelte](https://github.com/nstuyvesant/sveltekit-auth-example/blame/master/src/routes/%2Blayout.svelte#L60-L84)
Before
![image](https://github.com/nstuyvesant/sveltekit-auth-example/assets/1765616/b6987b68-9ebf-4251-8692-9cdd909857e7)

After
![image](https://github.com/nstuyvesant/sveltekit-auth-example/assets/1765616/90fe5185-09a0-4ce8-9a7c-f2b9dfb70e61)

